### PR TITLE
feat: added code for easier access to Sidetree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +885,17 @@ dependencies = [
  "libc",
  "match_cfg",
  "winapi",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1059,6 +1082,7 @@ dependencies = [
  "hdwallet",
  "hex",
  "hmac 0.12.1",
+ "http",
  "ibig",
  "k256 0.13.3",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_json = { version = "1.0.114" }
 sha2 = { version = "0.10.8" }
 thiserror = "1.0.58"
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"]}
+http = { version = "1.1.0"}
 
 [dev-dependencies]
 actix-rt = { version = "2.9.0" }

--- a/src/did/did_repository.rs
+++ b/src/did/did_repository.rs
@@ -57,6 +57,15 @@ pub struct DidRepositoryImpl<C: SidetreeHttpClient + Send + Sync> {
     client: C,
 }
 
+impl<C> Clone for DidRepositoryImpl<C>
+where
+    C: SidetreeHttpClient + Send + Sync + Clone,
+{
+    fn clone(&self) -> Self {
+        Self { client: self.client.clone() }
+    }
+}
+
 impl<C: SidetreeHttpClient + Send + Sync> DidRepositoryImpl<C> {
     pub fn new(client: C) -> Self {
         Self { client }

--- a/src/did/did_repository.rs
+++ b/src/did/did_repository.rs
@@ -1,9 +1,116 @@
-use crate::did::sidetree::payload::DIDResolutionResponse;
+use anyhow::Context;
+use http::StatusCode;
+
+use super::sidetree::{
+    client::{HttpError, SidetreeHttpClient},
+    payload::{CommitmentKeys, DIDCreateRequest, OperationPayloadBuilder},
+};
+use crate::{did::sidetree::payload::DIDResolutionResponse, keyring::keypair::KeyPairing};
+
+#[derive(Debug, thiserror::Error)]
+pub enum CreateIdentifierError {
+    #[error("Failed to convert public key: {0}")]
+    PublicKeyConvertFailed(crate::keyring::secp256k1::Secp256k1Error),
+    #[error("Failed to convert to JWK: {0}")]
+    JwkConvertFailed(#[from] crate::keyring::secp256k1::Secp256k1Error),
+    #[error("Failed to build operation payload: {0}")]
+    PayloadBuildFailed(#[from] crate::did::sidetree::payload::OperationPayloadBuilderError),
+    #[error("Failed to send request to sidetree: {0}")]
+    SidetreeRequestFailed(anyhow::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<HttpError> for CreateIdentifierError {
+    fn from(HttpError::Inner(e): HttpError) -> Self {
+        Self::SidetreeRequestFailed(e)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FindIdentifierError {
+    #[error("Failed to send request to sidetree: {0}")]
+    SidetreeRequestFailed(anyhow::Error),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<HttpError> for FindIdentifierError {
+    fn from(HttpError::Inner(e): HttpError) -> Self {
+        Self::SidetreeRequestFailed(e)
+    }
+}
 
 #[async_trait::async_trait]
 pub trait DidRepository {
-    async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse>;
-    async fn find_identifier(&self, did: &str) -> anyhow::Result<Option<DIDResolutionResponse>>;
+    async fn create_identifier(
+        &self,
+        keyring: KeyPairing,
+    ) -> Result<DIDResolutionResponse, CreateIdentifierError>;
+    async fn find_identifier(
+        &self,
+        did: &str,
+    ) -> Result<Option<DIDResolutionResponse>, FindIdentifierError>;
+}
+
+pub struct DidRepositoryImpl<C: SidetreeHttpClient + Send + Sync> {
+    client: C,
+}
+
+impl<C: SidetreeHttpClient + Send + Sync> DidRepositoryImpl<C> {
+    pub fn new(client: C) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait::async_trait]
+impl<C: SidetreeHttpClient + Send + Sync> DidRepository for DidRepositoryImpl<C> {
+    async fn create_identifier(
+        &self,
+        keyring: KeyPairing,
+    ) -> Result<DIDResolutionResponse, CreateIdentifierError> {
+        let public = keyring
+            .sign
+            .to_public_key("signingKey", &["auth", "general"])
+            .map_err(CreateIdentifierError::PublicKeyConvertFailed)?;
+
+        let update = keyring.update.to_jwk(false)?;
+        let recovery = keyring.recovery.to_jwk(false)?;
+        let payload = OperationPayloadBuilder::did_create_payload(&DIDCreateRequest {
+            public_keys: vec![public],
+            commitment_keys: CommitmentKeys { recovery, update },
+            service_endpoints: vec![],
+        })?;
+
+        let response = self.client.post_create_identifier(&payload).await?;
+        if response.status_code.is_success() {
+            let response = serde_json::from_str(&response.body).context("failed to parse body")?;
+            Ok(response)
+        } else {
+            Err(CreateIdentifierError::SidetreeRequestFailed(anyhow::anyhow!(
+                "Failed to create identifier. response: {:?}",
+                response
+            )))
+        }
+    }
+
+    async fn find_identifier(
+        &self,
+        did: &str,
+    ) -> Result<Option<DIDResolutionResponse>, FindIdentifierError> {
+        let response = self.client.get_find_identifier(did).await?;
+
+        match response.status_code {
+            StatusCode::OK => {
+                Ok(Some(serde_json::from_str(&response.body).context("failed to parse body")?))
+            }
+            StatusCode::NOT_FOUND => Ok(None),
+            _ => Err(FindIdentifierError::SidetreeRequestFailed(anyhow::anyhow!(
+                "Failed to find identifier. response: {:?}",
+                response
+            ))),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -29,15 +136,18 @@ pub mod mocks {
 
     #[async_trait::async_trait]
     impl DidRepository for MockDidRepository {
-        async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
+        async fn create_identifier(
+            &self,
+            _keyring: KeyPairing,
+        ) -> Result<DIDResolutionResponse, CreateIdentifierError> {
             unimplemented!()
         }
         async fn find_identifier(
             &self,
             did: &str,
-        ) -> anyhow::Result<Option<DIDResolutionResponse>> {
+        ) -> Result<Option<DIDResolutionResponse>, FindIdentifierError> {
             if let Some(keyring) = self.map.get(did) {
-                let jwk = keyring.sign.to_jwk(false)?;
+                let jwk = keyring.sign.to_jwk(false).unwrap();
 
                 let response = DIDResolutionResponse {
                     context: "https://www.w3.org/ns/did-resolution/v1".to_string(),
@@ -70,13 +180,16 @@ pub mod mocks {
 
     #[async_trait::async_trait]
     impl DidRepository for NoPublicKeyDidRepository {
-        async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
+        async fn create_identifier(
+            &self,
+            _keyring: KeyPairing,
+        ) -> Result<DIDResolutionResponse, CreateIdentifierError> {
             unimplemented!()
         }
         async fn find_identifier(
             &self,
             did: &str,
-        ) -> anyhow::Result<Option<DIDResolutionResponse>> {
+        ) -> Result<Option<DIDResolutionResponse>, FindIdentifierError> {
             Ok(Some(DIDResolutionResponse {
                 context: "https://www.w3.org/ns/did-resolution/v1".to_string(),
                 did_document: DIDDocument {
@@ -99,13 +212,16 @@ pub mod mocks {
 
     #[async_trait::async_trait]
     impl DidRepository for IllegalPublicKeyLengthDidRepository {
-        async fn create_identifier(&self) -> anyhow::Result<DIDResolutionResponse> {
+        async fn create_identifier(
+            &self,
+            _keyring: KeyPairing,
+        ) -> Result<DIDResolutionResponse, CreateIdentifierError> {
             unimplemented!()
         }
         async fn find_identifier(
             &self,
             did: &str,
-        ) -> anyhow::Result<Option<DIDResolutionResponse>> {
+        ) -> Result<Option<DIDResolutionResponse>, FindIdentifierError> {
             Ok(Some(DIDResolutionResponse {
                 context: "https://www.w3.org/ns/did-resolution/v1".to_string(),
                 did_document: DIDDocument {

--- a/src/did/sidetree/client.rs
+++ b/src/did/sidetree/client.rs
@@ -1,0 +1,50 @@
+use http::StatusCode;
+
+// This type isn't implement std::error::Error because of conflicting
+// implementations
+#[derive(Debug)]
+pub enum HttpError {
+    Inner(anyhow::Error),
+}
+
+impl<E> From<E> for HttpError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn from(e: E) -> Self {
+        Self::Inner(anyhow::Error::new(e))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SidetreeHttpClientResponse {
+    pub(crate) status_code: StatusCode,
+    pub(crate) body: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SidetreeResponseInitializationError {
+    #[error("Invalid status code: {0}")]
+    InvalidStatusCode(u16),
+}
+
+impl SidetreeHttpClientResponse {
+    pub fn new(
+        status_code: u16,
+        body: String,
+    ) -> Result<Self, SidetreeResponseInitializationError> {
+        let status_code = StatusCode::from_u16(status_code)
+            .map_err(|_| SidetreeResponseInitializationError::InvalidStatusCode(status_code))?;
+        Ok(Self { status_code, body })
+    }
+}
+
+#[async_trait::async_trait]
+pub trait SidetreeHttpClient {
+    async fn post_create_identifier(
+        &self,
+        body: &str,
+    ) -> Result<SidetreeHttpClientResponse, HttpError>;
+    async fn get_find_identifier(&self, did: &str)
+    -> Result<SidetreeHttpClientResponse, HttpError>;
+}

--- a/src/did/sidetree/mod.rs
+++ b/src/did/sidetree/mod.rs
@@ -1,1 +1,2 @@
+pub mod client;
 pub mod payload;

--- a/src/didcomm/encrypted.rs
+++ b/src/didcomm/encrypted.rs
@@ -15,7 +15,7 @@ use crate::{
         self,
         base64_url::{self, PaddingType},
     },
-    did::did_repository::DidRepository,
+    did::did_repository::{CreateIdentifierError, DidRepository, FindIdentifierError},
     didcomm::types::DIDCommMessage,
     keyring::{self, keypair::KeyPairing},
     verifiable_credentials::{
@@ -42,6 +42,10 @@ pub enum DIDCommEncryptedServiceGenerateError {
     DidPublicKeyNotFound(String),
     #[error("something went wrong with vc service")]
     VCServiceError(#[from] DIDVCServiceGenerateError),
+    #[error("failed to find identifier")]
+    SidetreeFindRequestFailed(#[from] FindIdentifierError),
+    #[error("failed to create identifier")]
+    SidetreeCreateRequestFailed(#[from] CreateIdentifierError),
     #[error("failed to encrypt message")]
     EncryptFailed(#[from] didcomm_rs::Error),
     #[error(transparent)]
@@ -56,6 +60,8 @@ pub enum DIDCommEncryptedServiceVerifyError {
     RuntimeSecp256k1Error(#[from] runtime::secp256k1::Secp256k1Error),
     #[error("did not found : {0}")]
     DIDNotFound(String),
+    #[error("failed to find identifier")]
+    SidetreeFindRequestFailed(#[from] FindIdentifierError),
     #[error("did public key not found : did = {0}")]
     DidPublicKeyNotFound(String),
     #[error(transparent)]

--- a/src/didcomm/encrypted.rs
+++ b/src/didcomm/encrypted.rs
@@ -146,15 +146,18 @@ impl DIDCommEncryptedService {
             )
         }
 
-        let seal_signed_message =
-            message.as_jwe(&CryptoAlgorithm::XC20P, Some(pk.as_bytes().to_vec())).seal_signed(
+        let seal_signed_message = message
+            .as_jwe(&CryptoAlgorithm::XC20P, Some(pk.as_bytes().to_vec()))
+            .seal_signed(
                 sk.to_bytes().as_ref(),
                 Some(vec![Some(pk.as_bytes().to_vec())]),
                 SignatureAlgorithm::Es256k,
                 &from_keyring.sign.get_secret_key(),
             )
             .map_err(|e| {
-                DIDCommEncryptedServiceGenerateError::EncryptFailed(anyhow::Error::msg(e.to_string()))
+                DIDCommEncryptedServiceGenerateError::EncryptFailed(anyhow::Error::msg(
+                    e.to_string(),
+                ))
             })?;
 
         Ok(serde_json::from_str::<DIDCommMessage>(&seal_signed_message)

--- a/src/verifiable_credentials/did_vc.rs
+++ b/src/verifiable_credentials/did_vc.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::{
-    did::did_repository::DidRepository,
+    did::did_repository::{DidRepository, FindIdentifierError},
     keyring::{self, keypair},
     verifiable_credentials::{
         credential_signer::{
@@ -41,6 +41,8 @@ pub enum DIDVCServiceVerifyError {
     VerifyFailed(#[from] CredentialSignerVerifyError),
     #[error("public_keys length must be 1")]
     PublicKeyLengthMismatch,
+    #[error("sidetree find request failed")]
+    SidetreeFindRequestFailed(#[from] FindIdentifierError),
     #[error("signature is not verified")]
     SignatureNotVerified,
     #[error(transparent)]


### PR DESCRIPTION
## Description

Currently, users need to implement the side tree request code, which is tedious.
Therefore, I've added a `SideTreeHttpClient` trait to facilitate access to Sidetree while still allowing customization of the http client.