### PR TITLE
fix(ci): change tag name setting in release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
             const release = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: "v${{ steps.set_crate_version.outputs.version }}",
+              tag_name: "${{ steps.set_crate_version.outputs.version }}",
               generate_release_notes: true
             });
             return release.data.id;


### PR DESCRIPTION
## Description

[Release Job](https://github.com/nodecross/nodex-didcomm/actions/runs/8420766257/job/23056146549) was failed.
 It was due to a wrong tag name.