### PR TITLE
chore: remove hmac library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,6 @@ dependencies = [
  "getrandom 0.2.12",
  "hdwallet",
  "hex",
- "hmac 0.12.1",
  "http",
  "ibig",
  "k256 0.13.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ didcomm-rs = { git = "https://github.com/nodecross/didcomm-rs.git", tag = "v0.8.
 getrandom = { version = "0.2" }
 hdwallet = { version = "0.4.1" }
 hex = { version = "0.4.3" }
-hmac = { version = "0.12.1" }
 http = { version = "1.1.0" }
 ibig = { version = "0.3.6" }
 k256 = { version = "0.13.3", features = [

--- a/src/common/runtime/secp256k1.rs
+++ b/src/common/runtime/secp256k1.rs
@@ -1,4 +1,5 @@
-use hmac::digest::generic_array::GenericArray;
+use std::convert::TryInto;
+
 use k256::{
     ecdsa::{
         signature::{Signer, Verifier},
@@ -65,8 +66,8 @@ impl Secp256k1 {
             return Err(Secp256k1Error::InvalidSignatureLength(signature.len()));
         }
 
-        let r = GenericArray::from_slice(&signature[0..32]);
-        let s = GenericArray::from_slice(&signature[32..]);
+        let r: &[u8; 32] = &signature[0..32].try_into().unwrap();
+        let s: &[u8; 32] = &signature[32..].try_into().unwrap();
 
         let wrapped_signature = Signature::from_scalars(*r, *s)?;
 


### PR DESCRIPTION
## Description

I've removed the `hmac` library, which isn`t necessary.